### PR TITLE
Naprawienie dzielenia grafu, wstępne uwzględnienie marginesu

### DIFF
--- a/graph.h
+++ b/graph.h
@@ -3,6 +3,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 typedef struct node {
     int arraySize; // Number of elements in allEdges array
@@ -37,7 +38,9 @@ graph declareGraph(const char *fileName);
 graph findNodeID(graph Miautoni, int nodeID);
 graph createGraph(const char *fileName);
 void printGraph(graph Graph);
+void notAlone(graph Graph, int partition);
+void addToInternalEdges(graph Graph, int takenNodeIndex, int aloneNodeIndex);
+void marginChecker(graph Graph, int partition, int margin);
 void freeGraph(graph Graph);
-void checkInputFile(char *fileName);
 
 #endif

--- a/main.c
+++ b/main.c
@@ -170,7 +170,9 @@ int main(int argc, char *argv[]) {
     initializeNodeLookupTable(Graph);
     KernighanLinAlgorithm(Graph);
     freeNodeLookupTable();
+    notAlone(Graph,partition);
     printGraph(Graph);
+    marginChecker(Graph,partition,margin);
     saveToTxt(Graph,inputFile,outputFile,partition);
     freeGraph(Graph);
     return EXIT_SUCCESS;


### PR DESCRIPTION
Poprawki zrobione na branchu saveBin, ponieważ zostały zauważone podczas tworzenia funkcji zapisującej wynik dzielenia.
- wstępne uwzględnienie marginesu na końcu podziału (sprawdzenie czy się zgadza z podanym przez użytkownika trzeba jeszcze dodać)
- lekkie zooptymalizowanie grupowania się wierzchołków